### PR TITLE
modify Join-Path

### DIFF
--- a/source.c
+++ b/source.c
@@ -1672,7 +1672,7 @@ void install(void)
 		file_write(&f, string_to_array("$env:WindowsSDKDir = (Join-Path $InstallPath '\\Windows Kits\\10')\n"));
 		file_write(&f, string_to_array("$VCToolsVersion = (Get-ChildItem -Directory (Join-Path $InstallPath '\\VC\\Tools\\MSVC' | Sort-Object -Descending LastWriteTime | Select-Object -First 1) -ErrorAction SilentlyContinue).Name\n"));
 		file_write(&f, string_to_array("if (!$VCToolsVersion) { throw 'VCToolsVersion cannot be determined.' }\n"));
-		file_write(&f, string_to_array("$env:VCToolsInstallDir = Join-Path $InstallPath '\\VC\\Tools\\MSVC' $VCToolsVersion\n"));
+		file_write(&f, string_to_array("$env:VCToolsInstallDir = Join-Path (Join-Path $InstallPath '\\VC\\Tools\\MSVC') $VCToolsVersion\n"));
 		file_write(&f, string_to_array("$env:WindowsSDKVersion = (Get-ChildItem -Directory (Join-Path $env:WindowsSDKDir 'bin') -ErrorAction SilentlyContinue | Sort-Object -Descending LastWriteTime | Select-Object -First 1).Name\n"));
 		file_write(&f, string_to_array("if (!$env:WindowsSDKVersion ) { throw 'WindowsSDKVersion cannot be determined.' }\n"));
 		string_format(array_expand(buf), "$env:VSCMD_ARG_TGT_ARCH = '{s}'\n", target_arch);


### PR DESCRIPTION
My powershell version is 5.1, when I run devcmd.ps1, it raises 
```
Join-Path : ...
...
+ ... sInstallDir = Join-Path $InstallPath '\VC\Tools\MSVC' $VCToolsVersion
+                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidArgument: (:) [Join-Path]，ParameterBindingException
    + FullyQualifiedErrorId : PositionalParameterNotFound,Microsoft.PowerShell.Commands.JoinPathCommand
```
It can work well when powershell version is 7.0+. Because in version 5.0，the command `Join-Path` is a little different from that on version 7.0+.
I chang below code
```
$env:VCToolsInstallDir = Join-Path $InstallPath '\VC\Tools\MSVC' $VCToolsVersion   #line 7
```
to 
```
$env:VCToolsInstallDir = Join-Path (Join-Path $InstallPath '\VC\Tools\MSVC') $VCToolsVersion   #line 7
```
It can work well as excepted.